### PR TITLE
Installation via DKMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ INSTALL_d = $(INSTALL) -d
 INSTALL_x = $(INSTALL)
 INSTALL_f = $(INSTALL) -m644
 
-prefix = /usr/local
+prefix =
 sysconfdir = $(prefix)/etc
 includedir = $(prefix)/include
 
@@ -62,17 +62,18 @@ kmodinstalldir = /lib/modules/$(KERNEL_VERSION)
 kmodincludedir = $(realpath $(KERNEL_SRC))/include/modules
 
 # If building the host's driver for a MIC co-processor card, which card
-# $(ARCH) it should support
+# $(ARCH) it should support (k1om by default)
+MIC_CARD_ARCH = k1om
 export MIC_CARD_ARCH
 
-.PHONY: all install modules
+.PHONY: all install modules clean
 .PHONY: modules_install conf_install dev_install kdev_install
 
 all: modules
 
 install: modules_install conf_install kdev_install
 
-modules modules_install: %:
+modules modules_install clean: %:
 	$(MAKE) -C $(KERNEL_SRC) M=$(CURDIR) $* \
 		INSTALL_MOD_PATH=$(DESTDIR)
 

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,75 @@
+# default options
+PREFIX= # empty means install into root
+ARCH=k1om
+CONFIG=1
+
+# parse some extra arguments
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--no-config )
+		CONFIG=0
+		shift ;;
+	-p  | --prefix )
+		[ $# -ge 2 ] || { echo "error: '$1' requires parameter" &1>2; exit 1; }
+		PREFIX="$2"
+		shift 2 ;;
+	-a  | --arch )
+		[ $# -ge 2 ] || { echo "error: '$1' requires parameter" &1>2; exit 1; }
+		ARCH="$2"
+		shift 2 ;;
+	-\? | --help )
+		cat <<-END
+		$0 [options]
+
+		flags:
+		  --no-config  do not install config files into /etc
+
+		options:
+		  -p, --prefix PREFIX   prefix for configuration files installation
+		  -k, --kernel VERSION  kernel version [manual install] (auto-detected)
+		  -a, --arch   ARCH     driver architecture (default: $ARCH)
+		END
+		exit 0 ;;
+	* ) echo "error: unknown option '$1'" &1>2; exit 1 ;;
+	esac
+done
+
+# require root
+if [ $EUID -ne 0 ]; then
+	echo "$0 must be run under as root. Try: 'sudo $0'" 1>&2
+	exit 1
+fi
+
+# check if DKMS is present, otherwise show some instructions
+if [ -z "$(which dkms 2>/dev/null)" ]; then
+	echo -n "$0 expects DKMS to be installed." 1>&2
+	if [ -n "$(which apt-get 2>/dev/null)" ]; then
+		echo " Try: 'sudo apt-get install dkms'"
+	elif [ -n "$(which yum 2>/dev/null)" ]; then
+		echo " Try: 'sudo yum install dkms'"
+	else
+		echo
+		echo "Install without DKMS using: 'make && sudo make install'"
+	fi
+	exit 1
+fi
+
+# get version information from Git tag
+if [ -n "$(which git 2>/dev/null)" ]; then
+	TAG=$(git describe)
+	TAG=${TAG%-g*} # strip Git version if any
+	VERSION=${TAG#*-}
+	NAME=${TAG%%-*}
+else # fallback to .mpss-metadata if Git is not present
+	read VERSION < .mpss-metadata
+	NAME=mpss
+	TAG=$NAME-$VERSION
+fi
+
+# make sure VERSION and NAME are set
+if [ -z "$VERSION" ] || [ -z "$NAME" ]; then
+	echo "Cannot find module version. Aborting." 1>&2
+	exit 1
+fi
+
+SRC="/usr/src/$TAG"

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,29 @@
-#! /bin/bash
+#!/bin/bash
+set -e # stop on error
+. common.sh
 
-KERNEL=$(uname -r)
-#KERNEL=3.9.9-ainan
-ARCH=k1om
+# install driver source code
+if [ ! -d "$SRC" ]; then
+	echo "Installing source to: $SRC"
+	# extract files into /usr/src
+	git archive --prefix="$TAG/" HEAD | sudo tar -x -C /usr/src
+	# write DKMS config
+	cat >"$SRC/dkms.conf" <<-END
+		PACKAGE_NAME=$NAME
+		PACKAGE_VERSION=$VERSION
+		MAKE[0]="make KERNEL_VERSION=\${kernelver} MIC_CARD_ARCH=$ARCH"
+		CLEAN=true
+		BUILT_MODULE_NAME[0]=mic
+		DEST_MODULE_LOCATION[0]=/extra
+		AUTOINSTALL=yes
+	END
+fi
 
-make KERNEL_VERSION=$KERNEL MIC_CARD_ARCH=$ARCH
-sudo make KERNEL_VERSION=$KERNEL MIC_CARD_ARCH=$ARCH sysconfdir=/etc includedir=/usr/include install
+dkms add $NAME/$VERSION
+dkms install $NAME/$VERSION
 
+# install additional udev rules
+if [ $CONFIG -eq 1 ]; then
+	echo "Installing configuration into: $PREFIX/etc"
+	make MIC_CARD_ARCH=$ARCH prefix=$PREFIX conf_install
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e # stop on error
+. common.sh
+
+# remove DKMS module
+dkms remove $NAME/$VERSION --all
+
+# remove source package
+if [ -d "$SRC" ]; then
+	echo "Removing source from: $SRC"
+	rm -rf "$SRC"
+fi


### PR DESCRIPTION
Installation via DKMS (with manual fallback)

This replaces install.sh/uninstall.sh with script installing sources into
/usr/src and adding them as DKMS module.

Using DKMS ensures MPSS drivers are installed & built on every kernel update.

See: http://linux.dell.com/dkms/manpage.html

Previous manual installation provided by: ./install --no-dkms
Help it provided by: ./install --help
